### PR TITLE
✨ (feat): exclude files from serving w/ `-e`  #16

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,8 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-/// `port` : takes an optional port number to serve on.
+// / `port` : takes an optional port number to serve on.
 var port string
+
+var exclude []string
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
@@ -28,11 +30,14 @@ func init() {
 	/// serves on port 8080 by default
 	/// can be changed using the -p / --port  flag
 	serveCmd.Flags().StringVarP(&port, "port", "p", "8080", "Port to serve on")
+
+	serveCmd.Flags().StringArrayVarP(&exclude, "exclude", "e", []string{}, "Type Files to Exclude from serving")
+
 	rootCmd.AddCommand(serveCmd)
 }
 
 func runServe(cmd *cobra.Command, args []string) {
-	srv := server.Spawn(port)
+	srv := server.Spawn(port, exclude)
 	if err := srv.Start(); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -18,16 +18,18 @@ import (
 type FileHandler struct {
 	dir      string
 	template *templates.Template
+	exclude  []string
 }
 
 ///
 ///
 /// [New] function creates a new FileHandler object with the given directory path and initializes them.
 
-func New(dir string) *FileHandler {
+func New(dir string, exclude []string) *FileHandler {
 	return &FileHandler{
 		dir:      dir,
 		template: templates.SpawnTemplate(),
+		exclude:  exclude,
 	}
 }
 
@@ -92,9 +94,13 @@ func (h *FileHandler) getFiles() ([]string, error) {
 		return nil, err
 	}
 
+	excludeContent := make(map[string]bool)
+	for _, e := range h.exclude {
+		excludeContent[e] = true
+	}
 	/// It ignores directories and returns only file names.
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !entry.IsDir() && !excludeContent[entry.Name()] {
 			files = append(files, entry.Name())
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,26 +9,28 @@ import (
 	"deepraj02/snoop/pkg/network"
 )
 
-///`port`: The port number on which the server listens.
-/// `dir`: The directory path where files are shared.
-/// `handler`: A FileHandler instance to handle file requests.
+// /`port`: The port number on which the server listens.
+// / `dir`: The directory path where files are shared.
+// / `handler`: A FileHandler instance to handle file requests.
 type Server struct {
 	port    string
 	dir     string
 	handler *handler.FileHandler
+	exclude []string
 }
 
-/// [Spawn] function creates a new Server object with the given port number and current directory path.
-func Spawn(port string) *Server {
+// / [Spawn] function creates a new Server object with the given port number and current directory path.
+func Spawn(port string, exclude []string) *Server {
 	dir, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	return &Server{
-		port:    port,
+		port: port,
 		dir:     dir,
-		handler: handler.New(dir),
+		exclude: exclude,
+		handler: handler.New(dir,exclude),
 	}
 }
 


### PR DESCRIPTION
This pull request introduces the ability to exclude specific file types from being served by the server. The changes span multiple files to integrate this new feature. The most important changes include adding the `exclude` flag, modifying the `FileHandler` and `Server` structs, and updating the file handling logic to respect the exclusion list.

### New Feature: File Exclusion

* [`cmd/serve.go`](diffhunk://#diff-fb0c696bc104f613e5b601c77c2eba916dd636d5948c9b5c8e85ea92ee5b07e6R16-R17): Added a new `exclude` flag to specify file types to exclude from serving. The `serveCmd` command now accepts this flag and passes it to the server spawn method. [[1]](diffhunk://#diff-fb0c696bc104f613e5b601c77c2eba916dd636d5948c9b5c8e85ea92ee5b07e6R16-R17) [[2]](diffhunk://#diff-fb0c696bc104f613e5b601c77c2eba916dd636d5948c9b5c8e85ea92ee5b07e6R33-R40)
* [`internal/handler/handler.go`](diffhunk://#diff-0097c8e59074fdb549fd2466fb349b2814b208df005f9ccf97b14568d51a5f0aR21-R32): Updated the `FileHandler` struct to include an `exclude` field. Modified the `New` function to accept the `exclude` parameter and updated the `getFiles` method to filter out files based on the exclusion list. [[1]](diffhunk://#diff-0097c8e59074fdb549fd2466fb349b2814b208df005f9ccf97b14568d51a5f0aR21-R32) [[2]](diffhunk://#diff-0097c8e59074fdb549fd2466fb349b2814b208df005f9ccf97b14568d51a5f0aR97-R103)
* [`internal/server/server.go`](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R19-R23): Updated the `Server` struct to include an `exclude` field. Modified the `Spawn` function to accept the `exclude` parameter and pass it to the `FileHandler`. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R19-R23) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23L31-R33)